### PR TITLE
fix: Invalid prop color of value dark

### DIFF
--- a/src/context/index.jsx
+++ b/src/context/index.jsx
@@ -33,7 +33,7 @@ export function reducer(state, action) {
 export function MaterialTailwindControllerProvider({ children }) {
   const initialState = {
     openSidenav: false,
-    sidenavColor: "dark",
+    sidenavColor: "gray",
     sidenavType: "white",
     transparentNavbar: true,
     fixedNavbar: false,


### PR DESCRIPTION
Hello! 

This fix Invalid prop color of value dark supplied to MaterialTailwind.Button 

 - Failed prop type: Invalid prop `color` of value `dark` supplied to `MaterialTailwind.Button`, expected one of ["white","blue-gray","gray","brown","deep-orange","orange","amber","yellow","lime","light-green","green","teal","cyan","light-blue","blue","indigo","deep-purple","purple","pink","red"]

Existe an issue opened to this bug: [Bug] Invalid prop color of value dark supplied to MaterialTailwind.Button

